### PR TITLE
新しいブランチを利用

### DIFF
--- a/Verification_Platform_default.ipynb
+++ b/Verification_Platform_default.ipynb
@@ -13,7 +13,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -25,7 +25,7 @@
       "source": [
         "#@title 必要なモジュールのインストール\n",
         "\n",
-        "!pip3 install git+https://github.com/iguchi-lab/pyhees-jjj.git@jjj-experiment\n",
+        "!pip3 install git+https://github.com/iguchi-lab/pyhees-jjj.git@jjj-experiment-v3.8\n",
         "#!pip3 install git+https://github.com/izumi-system-development/pyhees-jjj.git@jjj-experiment-WIP\n",
         "\n",
         "#以下は、ライブラリをアップグレードする場合に実行する。\n",


### PR DESCRIPTION
@iguchi-lab  先生

# 概要

ライブラリ側に用意した新しいブランチ `jjj-experiment-v3.8` をプラットフォームから利用するよう差し換え。
